### PR TITLE
Border radiuses for Hexagon widgets and grid.

### DIFF
--- a/lib/src/grid/hexagon_offset_grid.dart
+++ b/lib/src/grid/hexagon_offset_grid.dart
@@ -31,6 +31,7 @@ class HexagonOffsetGrid extends StatelessWidget {
   final int rows;
   final Color color;
   final double hexagonPadding;
+  final double hexagonBorderRadius;
   final Widget Function(int col, int row) buildChild;
   final HexagonWidget Function(int col, int row) buildHexagon;
 
@@ -44,6 +45,8 @@ class HexagonOffsetGrid extends StatelessWidget {
   ///
   /// [hexagonPadding] - Used for padding around all hexagon tiles. Will be overridden by template padding.
   ///
+  /// [hexagonBorderRadius] - Sets border radius for each hexagon tile. Will be overridden by template borderRadius.
+  ///
   /// [buildHexagon] - Provide a HexagonWidget.template() to be used for given tile (col,row). Returning null value will be represented as translucent tile.
   ///
   /// [buildChild] - Provide a Widget to be used in a HexagonWidget for given tile (col,row). Any returned value will override child provided in [buildHexagon] function.
@@ -54,6 +57,7 @@ class HexagonOffsetGrid extends StatelessWidget {
     this.buildChild,
     this.buildHexagon,
     this.hexagonPadding,
+    this.hexagonBorderRadius,
   })  : assert(columns > 0),
         assert(rows > 0),
         this.hexType = HexagonType.FLAT,
@@ -69,6 +73,8 @@ class HexagonOffsetGrid extends StatelessWidget {
   ///
   /// [hexagonPadding] - Used for padding around all hexagon tiles. Will be overridden by template padding.
   ///
+  /// [hexagonBorderRadius] - Sets border radius for each hexagon tile. Will be overridden by template borderRadius.
+  ///
   /// [buildHexagon] - Provide a HexagonWidget.template() to be used for given tile (col,row). Returning null value will be represented as translucent tile.
   ///
   /// [buildChild] - Provide a Widget to be used in a HexagonWidget for given tile (col,row). Any returned value will override child provided in [buildHexagon] function.
@@ -79,6 +85,7 @@ class HexagonOffsetGrid extends StatelessWidget {
     this.buildChild,
     this.buildHexagon,
     this.hexagonPadding,
+    this.hexagonBorderRadius,
   })  : this.hexType = HexagonType.FLAT,
         this.gridType = GridType.EVEN;
 
@@ -92,6 +99,8 @@ class HexagonOffsetGrid extends StatelessWidget {
   ///
   /// [hexagonPadding] - Used for padding around all hexagon tiles. Will be overridden by template padding.
   ///
+  /// [hexagonBorderRadius] - Sets border radius for each hexagon tile. Will be overridden by template borderRadius.
+  ///
   /// [buildHexagon] - Provide a HexagonWidget.template() to be used for given tile (col,row). Returning null value will be represented as translucent tile.
   ///
   /// [buildChild] - Provide a Widget to be used in a HexagonWidget for given tile (col,row). Any returned value will override child provided in [buildHexagon] function.
@@ -102,6 +111,7 @@ class HexagonOffsetGrid extends StatelessWidget {
     this.buildChild,
     this.buildHexagon,
     this.hexagonPadding,
+    this.hexagonBorderRadius,
   })  : this.hexType = HexagonType.POINTY,
         this.gridType = GridType.ODD;
 
@@ -115,6 +125,8 @@ class HexagonOffsetGrid extends StatelessWidget {
   ///
   /// [hexagonPadding] - Used for padding around all hexagon tiles. Will be overridden by template padding.
   ///
+  /// [hexagonBorderRadius] - Sets border radius for each hexagon tile. Will be overridden by template borderRadius.
+  ///
   /// [buildHexagon] - Provide a HexagonWidget.template() to be used for given tile (col,row). Returning null value will be represented as translucent tile.
   ///
   /// [buildChild] - Provide a Widget to be used in a HexagonWidget for given tile (col,row). Any returned value will override child provided in [buildHexagon] function.
@@ -125,6 +137,7 @@ class HexagonOffsetGrid extends StatelessWidget {
     this.buildChild,
     this.buildHexagon,
     this.hexagonPadding,
+    this.hexagonBorderRadius,
   })  : this.hexType = HexagonType.POINTY,
         this.gridType = GridType.EVEN;
 
@@ -180,6 +193,7 @@ class HexagonOffsetGrid extends StatelessWidget {
                     type: hexType,
                     inBounds: false,
                     padding: hexagonPadding,
+                    borderRadius: hexagonBorderRadius,
                     width: hexType.isPointy ? size.width : null,
                     height: hexType.isFlat ? size.height : null,
                     child: buildChild != null

--- a/lib/src/hexagon_clipper.dart
+++ b/lib/src/hexagon_clipper.dart
@@ -6,14 +6,16 @@ import 'hexagon_type.dart';
 import 'utils.dart';
 
 class HexagonClipper extends CustomClipper<Path> {
-  HexagonClipper(this.type, {this.inBounds});
+  HexagonClipper(this.type, {this.inBounds, this.borderRadius});
 
   final HexagonType type;
   final bool inBounds;
+  final double borderRadius;
 
   @override
   Path getClip(Size size) {
-    return HexagonUtils.hexagonPath(size, type, inBounds: inBounds);
+    return HexagonUtils.hexagonPath(size, type,
+        inBounds: inBounds, borderRadius: borderRadius);
   }
 
   @override

--- a/lib/src/hexagon_painter.dart
+++ b/lib/src/hexagon_painter.dart
@@ -5,12 +5,14 @@ import 'utils.dart';
 
 /// This class is responsible for painting HexagonWidget color and shadow in proper shape.
 class HexagonPainter extends CustomPainter {
-  HexagonPainter(this.type, {this.color, this.inBounds, this.elevation});
+  HexagonPainter(this.type,
+      {this.color, this.inBounds, this.elevation, this.borderRadius});
 
   final HexagonType type;
   final bool inBounds;
   final double elevation;
   final Color color;
+  final double borderRadius;
 
   final Paint _paint = Paint();
   Path _path;
@@ -21,7 +23,8 @@ class HexagonPainter extends CustomPainter {
     _paint.isAntiAlias = true;
     _paint.style = PaintingStyle.fill;
 
-    _path = HexagonUtils.hexagonPath(size, type, inBounds: inBounds);
+    _path = HexagonUtils.hexagonPath(size, type,
+        inBounds: inBounds, borderRadius: borderRadius);
     if ((elevation ?? 0) > 0)
       canvas.drawShadow(_path, Colors.black, elevation ?? 0, false);
     canvas.drawPath(_path, _paint);

--- a/lib/src/hexagon_widget.dart
+++ b/lib/src/hexagon_widget.dart
@@ -16,6 +16,8 @@ class HexagonWidget extends StatelessWidget {
   ///
   /// [color] - Color used to fill hexagon. Use transparency with 0 elevation
   ///
+  /// [borderRadius] - Border radius of hexagon corners. Values <= 0 have no effect.
+  ///
   /// [inBounds] - Set to false if you want to overlap hexagon corners outside it's space.
   ///
   /// [child] - You content. Keep in mind that it will be clipped.
@@ -30,6 +32,7 @@ class HexagonWidget extends StatelessWidget {
     this.padding,
     this.elevation = 0,
     this.inBounds = true,
+    this.borderRadius,
     @required this.type,
   })  : assert(width != null || height != null),
         assert((elevation ?? 0) >= 0),
@@ -45,6 +48,8 @@ class HexagonWidget extends StatelessWidget {
   ///
   /// [color] - Color used to fill hexagon. Use transparency with 0 elevation
   ///
+  /// [borderRadius] - Border radius of hexagon corners. Values <= 0 have no effect.
+  ///
   /// [inBounds] - Set to false if you want to overlap hexagon corners outside it's space.
   ///
   /// [child] - You content. Keep in mind that it will be clipped.
@@ -55,6 +60,7 @@ class HexagonWidget extends StatelessWidget {
       this.child,
       this.padding,
       this.elevation = 0,
+      this.borderRadius,
       this.inBounds = true})
       : assert(width != null || height != null),
         assert((elevation ?? 0) >= 0),
@@ -69,6 +75,8 @@ class HexagonWidget extends StatelessWidget {
   ///
   /// [color] - Color used to fill hexagon. Use transparency with 0 elevation
   ///
+  /// [borderRadius] - Border radius of hexagon corners. Values <= 0 have no effect.
+  ///
   /// [inBounds] - Set to false if you want to overlap hexagon corners outside it's space.
   ///
   /// [child] - You content. Keep in mind that it will be clipped.
@@ -79,6 +87,7 @@ class HexagonWidget extends StatelessWidget {
       this.child,
       this.padding,
       this.elevation = 0,
+      this.borderRadius,
       this.inBounds = true})
       : assert(width != null || height != null),
         assert((elevation ?? 0) >= 0),
@@ -86,7 +95,8 @@ class HexagonWidget extends StatelessWidget {
         this.type = HexagonType.POINTY;
 
   ///Used in grids. Not for regular use.
-  HexagonWidget.template({this.color, this.elevation, this.padding, this.child})
+  HexagonWidget.template({this.color, this.elevation, this.padding,
+    this.child, this.borderRadius})
       : this.height = 1.0,
         this.width = 1.0,
         this._template = true,
@@ -102,6 +112,7 @@ class HexagonWidget extends StatelessWidget {
   final Widget child;
   final Color color;
   final double padding;
+  final double borderRadius;
 
   bool get isTemplate => _template == true;
 
@@ -146,9 +157,14 @@ class HexagonWidget extends StatelessWidget {
             color: color,
             elevation: elevation,
             inBounds: inBounds,
+            borderRadius: borderRadius,
           ),
           child: ClipPath(
-            clipper: HexagonClipper(type, inBounds: inBounds),
+            clipper: HexagonClipper(
+              type,
+              inBounds: inBounds,
+              borderRadius: borderRadius,
+            ),
             child: OverflowBox(
               alignment: Alignment.center,
               maxHeight: contentSize.height,
@@ -174,6 +190,7 @@ class HexagonWidget extends StatelessWidget {
     Color color,
     Widget child,
     bool inBounds,
+    double borderRadius,
   }) {
     return HexagonWidget(
       type: type ?? this.type,
@@ -182,6 +199,7 @@ class HexagonWidget extends StatelessWidget {
       height: isTemplate ? height : height ?? this.height,
       child: isTemplate ? child : child ?? this.child,
       padding: isTemplate ? this.padding ?? padding : padding ?? this.padding,
+      borderRadius: isTemplate ? this.borderRadius ?? borderRadius : borderRadius ?? this.borderRadius,
       elevation: elevation ?? this.elevation,
       color: color ?? this.color,
     );

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -54,7 +54,8 @@ class HexagonUtils {
     Point prevCorner = index > 0
         ? cornerList[index - 1]
         : cornerList[cornerList.length - 1];
-    return pointBetween(corner, prevCorner, distance: radius);
+    double distance = radius * tan(pi / 6);
+    return pointBetween(corner, prevCorner, distance: distance);
   }
 
   static Point radiusEnd(Point corner, int index,
@@ -62,7 +63,8 @@ class HexagonUtils {
     Point nextCorner = index < cornerList.length - 1
         ? cornerList[index + 1]
         : cornerList[0];
-    return pointBetween(corner, nextCorner, distance: radius);
+    double distance = radius * tan(pi / 6);
+    return pointBetween(corner, nextCorner, distance: distance);
   }
 
   /// Returns path in shape of hexagon.
@@ -93,7 +95,7 @@ class HexagonUtils {
         } else {
           path.lineTo(rStart.x, rStart.y);
         }
-        // rough approximation of an circular arc for an 120 deg angle.
+        // rough approximation of an circular arc for 120 deg angle.
         Point control1 = pointBetween(rStart, point, fraction: 0.7698);
         Point control2 = pointBetween(rEnd, point, fraction: 0.7698);
         path.cubicTo(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -35,9 +35,41 @@ class HexagonUtils {
         growable: false,
       );
 
+  static Point pointBetween(Point start, Point end,
+      {double distance, double fraction}) {
+    double xLength = end.x - start.x;
+    double yLength = end.y - start.y;
+    if (fraction == null) {
+      if (distance == null) {
+        throw Exception('Distance or fraction should be specified.');
+      }
+      double length = sqrt(xLength * xLength + yLength * yLength);
+      fraction = distance / length;
+    }
+    return Point(start.x + xLength * fraction, start.y + yLength * fraction);
+  }
+
+  static Point radiusStart(Point corner, int index,
+      List<Point> cornerList, double radius) {
+    Point prevCorner = index > 0
+        ? cornerList[index - 1]
+        : cornerList[cornerList.length - 1];
+    return pointBetween(corner, prevCorner, distance: radius);
+  }
+
+  static Point radiusEnd(Point corner, int index,
+      List<Point> cornerList, double radius) {
+    Point nextCorner = index < cornerList.length - 1
+        ? cornerList[index + 1]
+        : cornerList[0];
+    return pointBetween(corner, nextCorner, distance: radius);
+  }
+
   /// Returns path in shape of hexagon.
-  static Path hexagonPath(Size size, HexagonType type, {bool inBounds}) {
+  static Path hexagonPath(Size size, HexagonType type,
+      {bool inBounds, double borderRadius}) {
     inBounds = inBounds == true;
+    borderRadius ??= 0;
     final center = Offset(size.width / 2, size.height / 2);
 
     List<Point> cornerList;
@@ -50,13 +82,36 @@ class HexagonUtils {
     }
 
     final path = Path();
-    cornerList.asMap().forEach((index, point) {
-      if (index == 0) {
-        path.moveTo(point.x, point.y);
-      } else {
-        path.lineTo(point.x, point.y);
-      }
-    });
+    if (borderRadius > 0) {
+      Point rStart;
+      Point rEnd;
+      cornerList.asMap().forEach((index, point) {
+        rStart = radiusStart(point, index, cornerList, borderRadius);
+        rEnd = radiusEnd(point, index, cornerList, borderRadius);
+        if (index == 0) {
+          path.moveTo(rStart.x, rStart.y);
+        } else {
+          path.lineTo(rStart.x, rStart.y);
+        }
+        // rough approximation of an circular arc for an 120 deg angle.
+        Point control1 = pointBetween(rStart, point, fraction: 0.7698);
+        Point control2 = pointBetween(rEnd, point, fraction: 0.7698);
+        path.cubicTo(
+          control1.x, control1.y,
+          control2.x, control2.y,
+          rEnd.x, rEnd.y,
+        );
+      });
+    } else {
+      cornerList.asMap().forEach((index, point) {
+        if (index == 0) {
+          path.moveTo(point.x, point.y);
+        } else {
+          path.lineTo(point.x, point.y);
+        }
+      });
+    }
+
     return path..close();
   }
 }


### PR DESCRIPTION
## Single widget example
```dart
HexagonWidget.flat(width: 300, color: Colors.redAccent, borderRadius: 15)
```
![Screenshot_1611123869](https://user-images.githubusercontent.com/8359639/105135817-d245d000-5b1a-11eb-83f8-64e446f29ff4.png)

## Grid example
```dart
HexagonOffsetGrid.oddPointy(
  columns: 2,
  rows: 4,
  color: Colors.black,
  hexagonPadding: 4,
  hexagonBorderRadius: 10,
  buildHexagon: (int col, int row) => HexagonWidget.template(color: Colors.yellow),
)
```
![Screenshot_1611123887](https://user-images.githubusercontent.com/8359639/105135926-fef9e780-5b1a-11eb-91b4-e9ad5850c34f.png)