### PR TITLE
README: [small fix] of `HexagonOffsetGrid.oddPointy` attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Column(
     HexagonOffsetGrid.oddPointy(
       columns: 5,
       rows: 10,
-      buildHexagon: (col, row) => HexagonWidgetBuilder(
+      buildTile: (col, row) => HexagonWidgetBuilder(
         color: row.isEven ? Colors.yellow : Colors.orangeAccent,
         elevation: 2,
       ),


### PR DESCRIPTION
There is no `buildHexagon` any more so I renamed it to valid `buildTile` attribute. Although there is `hexagonBuilder`, but it is mentioned in the text bellow code snippet, so I think `buildTile` is the intended one for the documentation code snippet, as there is an intent to use `(col, row)` parameters.