### PR TITLE
Add Parameters for borderWidth and borderColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ HexagonWidget.pointy(
 ),
 ```
 
+#### Borders
+You can add borders to hexagons using the `borderWidth` and `borderColor` properties:
+
+```dart
+HexagonWidget.flat(
+  width: 120,
+  color: Colors.white,
+  borderWidth: 3,
+  borderColor: Colors.black,
+  child: Text('Hexagon with border'),
+),
+HexagonWidget.pointy(
+  height: 100,
+  color: Colors.lightBlue,
+  borderWidth: 5,
+  borderColor: Colors.darkBlue,
+  elevation: 4,
+  child: Icon(Icons.star),
+),
+```
+
 ### Grids
 #### Offset Grid
 [Check Coordinates Offset on redblobgames](https://www.redblobgames.com/grids/hexagons/#coordinates-offset)

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,20 +78,24 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
             ],
           ),
           title: Text(widget.title),
-          actions: hasControls
-              ? [
-                  Row(children: [
-                    const Text('Controls'),
-                    Switch(
-                      value: showControls,
-                      activeColor: Colors.lightBlueAccent,
-                      onChanged: (value) => setState(() {
-                        showControls = value;
-                      }),
+          actions:
+              hasControls
+                  ? [
+                    Row(
+                      children: [
+                        const Text('Controls'),
+                        Switch(
+                          value: showControls,
+                          activeColor: Colors.lightBlueAccent,
+                          onChanged:
+                              (value) => setState(() {
+                                showControls = value;
+                              }),
+                        ),
+                      ],
                     ),
-                  ])
-                ]
-              : null,
+                  ]
+                  : null,
         ),
         body: TabBarView(
           controller: tabController,
@@ -110,17 +114,20 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                         margin: const EdgeInsets.all(8.0),
                         child: Padding(
                           padding: const EdgeInsets.symmetric(
-                              vertical: 2.0, horizontal: 16.0),
+                            vertical: 2.0,
+                            horizontal: 16.0,
+                          ),
                           child: Column(
                             mainAxisSize: MainAxisSize.min,
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               DropdownButton<HexagonType>(
-                                onChanged: (value) => setState(() {
-                                  if (value != null) {
-                                    type = value;
-                                  }
-                                }),
+                                onChanged:
+                                    (value) => setState(() {
+                                      if (value != null) {
+                                        type = value;
+                                      }
+                                    }),
                                 value: type,
                                 items: const [
                                   DropdownMenuItem<HexagonType>(
@@ -130,31 +137,36 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                                   DropdownMenuItem<HexagonType>(
                                     value: HexagonType.POINTY,
                                     child: Text('Pointy'),
-                                  )
+                                  ),
                                 ],
-                                selectedItemBuilder: (context) =>
-                                [
-                                  const Center(child: Text('Flat')),
-                                  const Center(child: Text('Pointy')),
-                                ],
+                                selectedItemBuilder:
+                                    (context) => [
+                                      const Center(child: Text('Flat')),
+                                      const Center(child: Text('Pointy')),
+                                    ],
                               ),
                               DropdownButton<int>(
-                                onChanged: (value) => setState(() {
-                                  if (value != null) {
-                                    depth = value;
-                                  }
-                                }),
+                                onChanged:
+                                    (value) => setState(() {
+                                      if (value != null) {
+                                        depth = value;
+                                      }
+                                    }),
                                 value: depth,
-                                items: depths
-                                    .map((e) => DropdownMenuItem<int>(
-                                          value: e,
-                                          child: Text('Depth: $e'),
-                                        ))
-                                    .toList(),
+                                items:
+                                    depths
+                                        .map(
+                                          (e) => DropdownMenuItem<int>(
+                                            value: e,
+                                            child: Text('Depth: $e'),
+                                          ),
+                                        )
+                                        .toList(),
                                 selectedItemBuilder: (context) {
                                   return depths
-                                      .map((e) =>
-                                          Center(child: Text('Depth: $e')))
+                                      .map(
+                                        (e) => Center(child: Text('Depth: $e')),
+                                      )
                                       .toList();
                                 },
                               ),
@@ -184,12 +196,13 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         hexType: type,
         color: Colors.pink,
         depth: depth,
-        buildTile: (coordinates) => HexagonWidgetBuilder(
-          padding: 2.0,
-          cornerRadius: 8.0,
-          child: Text('${coordinates.q}, ${coordinates.r}'),
-          // Text('${coordinates.x}, ${coordinates.y}, ${coordinates.z}\n  ${coordinates.q}, ${coordinates.r}'),
-        ),
+        buildTile:
+            (coordinates) => HexagonWidgetBuilder(
+              padding: 2.0,
+              cornerRadius: 8.0,
+              child: Text('${coordinates.q}, ${coordinates.r}'),
+              // Text('${coordinates.x}, ${coordinates.y}, ${coordinates.z}\n  ${coordinates.q}, ${coordinates.r}'),
+            ),
       ),
     );
   }
@@ -202,15 +215,20 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 32.0),
         columns: 9,
         rows: 4,
-        buildTile: (col, row) => row.isOdd && col.isOdd
-            ? null
-            : HexagonWidgetBuilder(
-                elevation: col.toDouble(),
-                padding: 4.0,
-                cornerRadius: row.isOdd ? 24.0 : null,
-                color: col == 1 || row == 1 ? Colors.lightBlue.shade200 : null,
-                child: Text('$col, $row'),
-              ),
+        buildTile:
+            (col, row) =>
+                row.isOdd && col.isOdd
+                    ? null
+                    : HexagonWidgetBuilder(
+                      elevation: col.toDouble(),
+                      padding: 4.0,
+                      cornerRadius: row.isOdd ? 24.0 : null,
+                      color:
+                          col == 1 || row == 1
+                              ? Colors.lightBlue.shade200
+                              : null,
+                      child: Text('$col, $row'),
+                    ),
       ),
     );
   }
@@ -225,11 +243,12 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
             padding: const EdgeInsets.all(8.0),
             columns: 5,
             rows: 10,
-            buildTile: (col, row) => HexagonWidgetBuilder(
-              color: row.isEven ? Colors.yellow : Colors.orangeAccent,
-              elevation: 2.0,
-              padding: 2.0,
-            ),
+            buildTile:
+                (col, row) => HexagonWidgetBuilder(
+                  color: row.isEven ? Colors.yellow : Colors.orangeAccent,
+                  elevation: 2.0,
+                  padding: 2.0,
+                ),
             buildChild: (col, row) => Text('$col, $row'),
           ),
         ],
@@ -255,10 +274,7 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                   width: w,
                   child: AspectRatio(
                     aspectRatio: HexagonType.FLAT.ratio,
-                    child: Image.asset(
-                      'assets/bee.jpg',
-                      fit: BoxFit.fitHeight,
-                    ),
+                    child: Image.asset('assets/bee.jpg', fit: BoxFit.fitHeight),
                   ),
                 ),
               ),
@@ -268,10 +284,7 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                   width: w,
                   child: AspectRatio(
                     aspectRatio: HexagonType.POINTY.ratio,
-                    child: Image.asset(
-                      'assets/tram.jpg',
-                      fit: BoxFit.fitWidth,
-                    ),
+                    child: Image.asset('assets/tram.jpg', fit: BoxFit.fitWidth),
                   ),
                 ),
               ),
@@ -293,7 +306,11 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                 child: HexagonWidget.pointy(
                   height: h,
                   color: Colors.red,
-                  child: Text('pointy\nheight: ${h.toStringAsFixed(2)}'),
+                  borderWidth: 5,
+                  borderColor: Colors.amber,
+                  child: Text(
+                    'pointy\nheight: ${h.toStringAsFixed(2)}\nborder',
+                  ),
                 ),
               ),
             ],
@@ -312,7 +329,22 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
             child: HexagonWidget.pointy(
               width: w,
               color: Colors.lightBlue,
-              child: Text('pointy\nwidth: ${w.toStringAsFixed(2)}'),
+              elevation: 10,
+              child: Text(
+                'pointy\nwidth: ${w.toStringAsFixed(2)}\nelevation: 10',
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.all(padding),
+            child: HexagonWidget.pointy(
+              width: w,
+              borderColor: Colors.red,
+              borderWidth: 10,
+              color: Colors.lightBlue,
+              child: Text(
+                'pointy\nwidth: ${w.toStringAsFixed(2)} \nborderWidth: 10, borderColor: Colors.red',
+              ),
             ),
           ),
         ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,42 +5,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -82,14 +82,30 @@ packages:
       relative: true
     source: path
     version: "0.2.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      name: leak_tracker
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "10.0.8"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -102,87 +118,87 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -191,6 +207,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.3.1"
 sdks:
-  dart: ">=2.19.6 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.7.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/hexagon_painter.dart
+++ b/lib/src/hexagon_painter.dart
@@ -4,27 +4,49 @@ import 'hexagon_path_builder.dart';
 
 /// This class is responsible for painting HexagonWidget color and shadow in proper shape.
 class HexagonPainter extends CustomPainter {
-  HexagonPainter(this.pathBuilder, {this.color, this.elevation = 0});
+  HexagonPainter(
+    this.pathBuilder, {
+    this.color,
+    this.elevation = 0,
+    this.borderColor,
+    this.borderWidth = 0,
+  });
 
   final HexagonPathBuilder pathBuilder;
   final double elevation;
   final Color? color;
+  final Color? borderColor;
+  final double borderWidth;
 
   final Paint _paint = Paint();
+  final Paint _borderPaint = Paint();
   Path? _path;
 
   @override
   void paint(Canvas canvas, Size size) {
-    _paint.color = color ?? Colors.white;
-    _paint.isAntiAlias = true;
-    _paint.style = PaintingStyle.fill;
-
     Path path = pathBuilder.build(size);
     _path = path;
 
-    if ((elevation) > 0)
+    // Draw shadow
+    if (elevation > 0) {
       canvas.drawShadow(path, Colors.black, elevation, false);
+    }
+
+    // Draw fill
+    // keep default as white to not cause breaking changes
+    _paint.color = color ?? Colors.white;
+    _paint.isAntiAlias = true;
+    _paint.style = PaintingStyle.fill;
     canvas.drawPath(path, _paint);
+
+    // Draw border
+    if (borderWidth > 0 && borderColor != null) {
+      _borderPaint.color = borderColor!;
+      _borderPaint.isAntiAlias = true;
+      _borderPaint.style = PaintingStyle.stroke;
+      _borderPaint.strokeWidth = borderWidth;
+      canvas.drawPath(path, _borderPaint);
+    }
   }
 
   @override
@@ -44,9 +66,15 @@ class HexagonPainter extends CustomPainter {
           runtimeType == other.runtimeType &&
           pathBuilder == other.pathBuilder &&
           elevation == other.elevation &&
-          color == other.color;
+          color == other.color &&
+          borderColor == other.borderColor &&
+          borderWidth == other.borderWidth;
 
   @override
   int get hashCode =>
-      pathBuilder.hashCode ^ elevation.hashCode ^ color.hashCode;
+      pathBuilder.hashCode ^
+      elevation.hashCode ^
+      color.hashCode ^
+      borderColor.hashCode ^
+      borderWidth.hashCode;
 }

--- a/lib/src/hexagon_widget.dart
+++ b/lib/src/hexagon_widget.dart
@@ -23,6 +23,11 @@ class HexagonWidget extends StatelessWidget {
   /// [child] - You content. Keep in mind that it will be clipped.
   ///
   /// [type] - A type of hexagon has to be either [HexagonType.FLAT] or [HexagonType.POINTY]
+  ///
+  /// [borderWidth] - Width of the hexagon border. Default = 0
+  ///
+  /// [borderColor] - Color of the hexagon border
+  ///
   const HexagonWidget({
     Key? key,
     this.width,
@@ -33,10 +38,12 @@ class HexagonWidget extends StatelessWidget {
     this.cornerRadius = 0.0,
     this.elevation = 0,
     this.inBounds = true,
+    this.borderWidth = 0,
+    this.borderColor,
     required this.type,
-  })  : assert(width != null || height != null),
-        assert(elevation >= 0),
-        super(key: key);
+  }) : assert(width != null || height != null),
+       assert(elevation >= 0),
+       super(key: key);
 
   /// Preferably provide one dimension ([width] or [height]) and the other will be calculated accordingly to hexagon aspect ratio
   ///
@@ -51,6 +58,10 @@ class HexagonWidget extends StatelessWidget {
   /// [inBounds] - Set to false if you want to overlap hexagon corners outside it's space.
   ///
   /// [child] - You content. Keep in mind that it will be clipped.
+  ///
+  /// [borderWidth] - Width of the hexagon border. Default = 0
+  ///
+  /// [borderColor] - Color of the hexagon border
   HexagonWidget.flat({
     Key? key,
     this.width,
@@ -61,10 +72,12 @@ class HexagonWidget extends StatelessWidget {
     this.elevation = 0,
     this.cornerRadius = 0.0,
     this.inBounds = true,
-  })  : assert(width != null || height != null),
-        assert(elevation >= 0),
-        this.type = HexagonType.FLAT,
-        super(key: key);
+    this.borderWidth = 0,
+    this.borderColor,
+  }) : assert(width != null || height != null),
+       assert(elevation >= 0),
+       this.type = HexagonType.FLAT,
+       super(key: key);
 
   /// Preferably provide one dimension ([width] or [height]) and the other will be calculated accordingly to hexagon aspect ratio
   ///
@@ -79,6 +92,10 @@ class HexagonWidget extends StatelessWidget {
   /// [inBounds] - Set to false if you want to overlap hexagon corners outside it's space.
   ///
   /// [child] - You content. Keep in mind that it will be clipped.
+  ///
+  /// [borderWidth] - Width of the hexagon border. Default = 0
+  ///
+  /// [borderColor] - Color of the hexagon border
   HexagonWidget.pointy({
     Key? key,
     this.width,
@@ -89,10 +106,12 @@ class HexagonWidget extends StatelessWidget {
     this.elevation = 0,
     this.cornerRadius = 0.0,
     this.inBounds = true,
-  })  : assert(width != null || height != null),
-        assert(elevation >= 0),
-        this.type = HexagonType.POINTY,
-        super(key: key);
+    this.borderWidth = 0,
+    this.borderColor,
+  }) : assert(width != null || height != null),
+       assert(elevation >= 0),
+       this.type = HexagonType.POINTY,
+       super(key: key);
 
   final HexagonType type;
   final double? width;
@@ -103,6 +122,8 @@ class HexagonWidget extends StatelessWidget {
   final Color? color;
   final double padding;
   final double cornerRadius;
+  final double borderWidth;
+  final Color? borderColor;
 
   Size _innerSize() {
     var flatFactor = type.flatFactor(inBounds);
@@ -123,7 +144,9 @@ class HexagonWidget extends StatelessWidget {
     if (height != null && width != null) return Size(width!, height!);
     if (height != null)
       return Size(
-          (height! * type.ratio) / pointyFactor, height! / pointyFactor);
+        (height! * type.ratio) / pointyFactor,
+        height! / pointyFactor,
+      );
     if (width != null)
       return Size(width! / flatFactor, (width! / type.ratio) / flatFactor);
     return Size.zero; //dead path
@@ -134,8 +157,11 @@ class HexagonWidget extends StatelessWidget {
     var innerSize = _innerSize();
     var contentSize = _contentSize();
 
-    HexagonPathBuilder pathBuilder = HexagonPathBuilder(type,
-        inBounds: inBounds, borderRadius: cornerRadius);
+    HexagonPathBuilder pathBuilder = HexagonPathBuilder(
+      type,
+      inBounds: inBounds,
+      borderRadius: cornerRadius,
+    );
 
     return Align(
       child: Container(
@@ -147,6 +173,8 @@ class HexagonWidget extends StatelessWidget {
             pathBuilder,
             color: color,
             elevation: elevation,
+            borderColor: borderColor,
+            borderWidth: borderWidth,
           ),
           child: ClipPath(
             clipper: HexagonClipper(pathBuilder),
@@ -154,10 +182,7 @@ class HexagonWidget extends StatelessWidget {
               alignment: Alignment.center,
               maxHeight: contentSize.height,
               maxWidth: contentSize.width,
-              child: Align(
-                alignment: Alignment.center,
-                child: child,
-              ),
+              child: Align(alignment: Alignment.center, child: child),
             ),
           ),
         ),
@@ -173,6 +198,8 @@ class HexagonWidgetBuilder {
   final double? padding;
   final double? cornerRadius;
   final Widget? child;
+  final double? borderWidth;
+  final Color? borderColor;
 
   HexagonWidgetBuilder({
     this.key,
@@ -181,6 +208,8 @@ class HexagonWidgetBuilder {
     this.padding,
     this.cornerRadius,
     this.child,
+    this.borderWidth,
+    this.borderColor,
   });
 
   HexagonWidgetBuilder.transparent({
@@ -188,8 +217,10 @@ class HexagonWidgetBuilder {
     this.padding,
     this.cornerRadius,
     this.child,
-  })  : this.elevation = 0,
-        this.color = Colors.transparent;
+    this.borderWidth,
+    this.borderColor,
+  }) : this.elevation = 0,
+       this.color = Colors.transparent;
 
   HexagonWidget build({
     required HexagonType type,
@@ -210,6 +241,8 @@ class HexagonWidgetBuilder {
       padding: padding ?? 0.0,
       cornerRadius: cornerRadius ?? 0.0,
       elevation: elevation ?? 0,
+      borderWidth: borderWidth ?? 0,
+      borderColor: borderColor,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -59,99 +59,115 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      name: leak_tracker
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "10.0.8"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -160,6 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.3.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.7.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/test/hexagon_test.dart
+++ b/test/hexagon_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hexagon/hexagon.dart';
 import 'package:hexagon/src/hexagon_path_builder.dart';
@@ -6,24 +7,85 @@ import 'package:hexagon/src/hexagon_path_builder.dart';
 void main() {
   testWidgets('HexagonWidget exists.', (WidgetTester tester) async {
     // Test code goes here.
-    await tester.pumpWidget(Center(
-      child: HexagonWidget(
-        type: HexagonType.FLAT,
-        height: 100,
-      ),
-    ));
+    await tester.pumpWidget(
+      Center(child: HexagonWidget(type: HexagonType.FLAT, height: 100)),
+    );
 
     expect(find.byType(HexagonWidget), findsOneWidget);
   });
 
   testWidgets('HexagonGird', (WidgetTester tester) async {
-    await tester.pumpWidget(HexagonGrid.flat(
-      height: 660,
-      width: 633,
-      depth: 1,
-    ));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: HexagonGrid.flat(height: 200, width: 200, depth: 1),
+          ),
+        ),
+      ),
+    );
 
     expect(find.byType(HexagonGrid), findsOneWidget);
+  });
+
+  testWidgets('HexagonWidget with border', (WidgetTester tester) async {
+    // Test creating a hexagon with a border
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: HexagonWidget(
+              type: HexagonType.FLAT,
+              height: 100,
+              borderWidth: 3,
+              borderColor: const Color(0xFF000000), // Black border
+              color: const Color(0xFFFFFFFF), // White fill
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(HexagonWidget), findsOneWidget);
+
+    // Verify that the hexagon widget was created
+    final hexagonWidget = tester.widget<HexagonWidget>(
+      find.byType(HexagonWidget),
+    );
+    expect(hexagonWidget.borderWidth, equals(3));
+    expect(hexagonWidget.borderColor, equals(const Color(0xFF000000)));
+    expect(hexagonWidget.color, equals(const Color(0xFFFFFFFF)));
+    expect(hexagonWidget.type, equals(HexagonType.FLAT));
+  });
+
+  testWidgets('HexagonWidget.pointy with border', (WidgetTester tester) async {
+    // Test creating a pointy hexagon with a border using named constructor
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: HexagonWidget.pointy(
+              width: 120,
+              borderWidth: 5,
+              borderColor: const Color(0xFFFF0000), // Red border
+              color: const Color(0xFF00FF00), // Green fill
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(HexagonWidget), findsOneWidget);
+
+    // Verify properties of the pointy hexagon with border
+    final hexagonWidget = tester.widget<HexagonWidget>(
+      find.byType(HexagonWidget),
+    );
+    expect(hexagonWidget.borderWidth, equals(5));
+    expect(hexagonWidget.borderColor, equals(const Color(0xFFFF0000)));
+    expect(hexagonWidget.color, equals(const Color(0xFF00FF00)));
+    expect(hexagonWidget.type, equals(HexagonType.POINTY));
+    expect(hexagonWidget.width, equals(120));
   });
 
   test("HexagonPainter test", () {
@@ -34,13 +96,14 @@ void main() {
   test("HexagonPathBuilder test", () {
     var flat = HexagonPathBuilder(HexagonType.FLAT);
     var flat2 = HexagonPathBuilder(HexagonType.FLAT, inBounds: true);
+    var flat3 = HexagonPathBuilder(HexagonType.FLAT, inBounds: false);
     var pointy = HexagonPathBuilder(HexagonType.POINTY, borderRadius: 2.0);
     var pointy2 = HexagonPathBuilder(HexagonType.POINTY, borderRadius: 2);
 
-    expect(flat == flat, true);
-    expect(flat != flat2, true);
-    expect(flat != pointy, true);
-    expect(pointy == pointy2, true);
+    expect(flat == flat2, true); // Same type, same default inBounds value
+    expect(flat != flat3, true); // Same type, different inBounds value
+    expect(flat != pointy, true); // Different type
+    expect(pointy == pointy2, true); // Same type, same borderRadius values
   });
   test("Coordinates distance", () {
     var zero = Coordinates.zero;


### PR DESCRIPTION
# Add border support with tests and documentation

Not sure if this repo is still active, but I found it very useful and I see that other users like in #27 had the same wish as me, so I created this PR.

## Feature
Added `borderWidth` and `borderColor` properties to HexagonWidget.

## Changes
- Added tests for hexagon borders (both flat and pointy types)
- Updated README.md with border usage examples
- Fixed existing failing tests

## Usage
```dart
HexagonWidget.flat(
  width: 120,
  borderWidth: 3,
  borderColor: Colors.black,
  child: Text('Bordered hexagon'),
)
```

```dart
 HexagonGrid(
        hexType: type,
        color: Colors.pink,
        depth: depth,
        buildTile:
            (coordinates) => HexagonWidgetBuilder(
              padding: 4.0,
              borderWidth: 4,
              borderColor: Colors.green,
              cornerRadius: 4.0,
              child: Text('${coordinates.q}, ${coordinates.r}'),
            ),
      ),
```

Screenshot:
<img width="1101" height="946" alt="image" src="https://github.com/user-attachments/assets/73814a0a-5c57-4252-a527-84293186b5fa" />


All tests passing ✅